### PR TITLE
Revert "sanders: dts: msm: Mount the system partition during early init"

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8953.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8953.dtsi
@@ -26,23 +26,6 @@
 		bootargs = "sched_enable_hmp=1 sched_enable_power_aware=1";
 	};
 
-	firmware: firmware {
-		android {
-			compatible = "android,firmware";
-			fstab {
-				compatible = "android,fstab";
-				system {
-					compatible = "android,system";
-					dev = "/dev/block/platform/soc/7824900.sdhci/by-name/system";
-					type = "ext4";
-					mnt_flags = "ro,barrier=1,discard";
-					fsmgr_flags = "wait";
-					status = "ok";
-				};
-			};
-		};
-	};
-
 	reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;


### PR DESCRIPTION
This reverts commit 33be0dbde6b34d2224005b070727f802d5dcd3ce.